### PR TITLE
[v2/refactor] Move interactionCreate to dedicated file/module, add Actions (context menu) support

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,0 +1,21 @@
+/**
+ * Defines the structure of an Action.
+ *
+ * @typedef {object} Action
+ * @property {import('discord.js').RESTPostAPIApplicationCommandsJSONBody} data The data for the command
+ * @property {(interaction: import('discord.js').ContextMenuCommandInteraction) => Promise<void> | void} execute The function to execute when the command is called
+ */
+
+/**
+ * Defines the predicate to check if an object is a valid Command type.
+ *
+ * @type {import('../util/loaders.js').StructurePredicate<Action>}
+ * @returns {structure is Action}
+ */
+export const predicate = (structure) =>
+	Boolean(structure) &&
+	typeof structure === "object" &&
+	"data" in structure &&
+	"execute" in structure &&
+	typeof structure.data === "object" &&
+	typeof structure.execute === "function";

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -1,0 +1,27 @@
+import { Events } from "discord.js";
+import chalk from "chalk";
+
+/** @type {import('./index.js').Event<Events.InteractionCreate>} */
+export default {
+	name: Events.InteractionCreate,
+	async execute(interaction) {
+		const client = interaction.client;
+		const commands = client.commands;
+
+		if (interaction.isCommand()) {
+			const command = commands.get(interaction.commandName);
+
+			if (!command) {
+				throw new Error(`Command '${interaction.commandName}' not found.`);
+			}
+
+			await command.execute(interaction).catch((e) => {
+				console.log(
+					`${chalk.bold.red("Command")} exception (${interaction.commandName}): \n`,
+					e,
+					` ${Temporal.Now.instant().toLocaleString("en-GB", { timeZone: "Etc/UTC", timeZoneName: "short" })}`,
+				);
+			});
+		}
+	},
+};

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -6,9 +6,26 @@ export default {
 	name: Events.InteractionCreate,
 	async execute(interaction) {
 		const client = interaction.client;
-		const commands = client.commands;
+		const commands = client.commandsMap;
+		const actions = client.actionsMap;
 
-		if (interaction.isCommand()) {
+		if (interaction.isContextMenuCommand()) {
+			const action = actions.get(interaction.commandName);
+
+			if (!action) {
+				throw new Error(`Action '${interaction.commandName}' not found.`);
+			}
+
+			await action.execute(interaction).catch((e) => {
+				console.log(
+					`${chalk.bold.red("Action")} exception (${interaction.commandName}): \n`,
+					e,
+					` ${Temporal.Now.instant().toLocaleString("en-GB", { timeZone: "Etc/UTC", timeZoneName: "short" })}`,
+				);
+			});
+		}
+
+		if (interaction.isChatInputCommand()) {
 			const command = commands.get(interaction.commandName);
 
 			if (!command) {

--- a/src/index.js
+++ b/src/index.js
@@ -27,9 +27,10 @@ await cmdRollout();
 // Load the events and commands
 const events = await loadEvents(new URL("events/", import.meta.url));
 const commands = await loadCommands(new URL("commands/", import.meta.url));
+const actions = await loadCommands(new URL("actions/", import.meta.url));
 
 // Register the event handlers
-registerEvents(commands, events, client);
+registerEvents(commands, actions, events, client);
 
 // Login to the client
 void client.login(process.env.DISCORD_TOKEN);

--- a/src/util/deploy.js
+++ b/src/util/deploy.js
@@ -11,9 +11,8 @@ export const cmdRollout = async () => {
 	const env = new Environment();
 
 	const commands = await loadCommands(new URL("../commands/", import.meta.url));
-	const commandData = [...commands.values()]
-		.filter((c) => !c.type || c.type === "command")
-		.map((command) => command.data);
+	const actions = await loadCommands(new URL("../actions/", import.meta.url));
+	const data = [...commands.values(), ...actions.values()].map((command) => command.data);
 
 	const rest = new REST({ version: "10" }).setToken(process.env.DISCORD_TOKEN);
 	const api = new API(rest);
@@ -23,11 +22,11 @@ export const cmdRollout = async () => {
 			? await api.applicationCommands.bulkOverwriteGuildCommands(
 					process.env.APPLICATION_ID,
 					process.env.DEV_GUILD,
-					commandData,
+					data,
 				)
-			: await api.applicationCommands.bulkOverwriteGlobalCommands(process.env.APPLICATION_ID, commandData);
+			: await api.applicationCommands.bulkOverwriteGlobalCommands(process.env.APPLICATION_ID, data);
 
 	console.log(
-		`${chalk.bold.green("Core")} Successfully registered ${chalk.bold(result.length)} commands (${Temporal.Now.instant().toLocaleString("en-GB", { timeZone: "Etc/UTC", timeZoneName: "short" })})`,
+		`${chalk.bold.green("Core")} Successfully registered ${chalk.bold(result.length)} commands/actions (${Temporal.Now.instant().toLocaleString("en-GB", { timeZone: "Etc/UTC", timeZoneName: "short" })})`,
 	);
 };

--- a/src/util/deploy.js
+++ b/src/util/deploy.js
@@ -1,23 +1,25 @@
-import process from 'node:process';
-import { URL } from 'node:url';
-import { API } from '@discordjs/core/http-only';
-import { REST } from 'discord.js';
-import { Environment } from './helpers.js';
-import { loadCommands } from './loaders.js';
+import process from "node:process";
+import { URL } from "node:url";
+import { API } from "@discordjs/core/http-only";
+import { REST } from "discord.js";
+import { Environment } from "./helpers.js";
+import { loadCommands } from "./loaders.js";
 
-import chalk from 'chalk';
+import chalk from "chalk";
 
 export const cmdRollout = async () => {
 	const env = new Environment();
 
-	const commands = await loadCommands(new URL('../commands/', import.meta.url));
-	const commandData = [...commands.values()].map((command) => command.data);
+	const commands = await loadCommands(new URL("../commands/", import.meta.url));
+	const commandData = [...commands.values()]
+		.filter((c) => !c.type || c.type === "command")
+		.map((command) => command.data);
 
-	const rest = new REST({ version: '10' }).setToken(process.env.DISCORD_TOKEN);
+	const rest = new REST({ version: "10" }).setToken(process.env.DISCORD_TOKEN);
 	const api = new API(rest);
 
 	const result =
-		env.getRuntimeScenario() === 'development'
+		env.getRuntimeScenario() === "development"
 			? await api.applicationCommands.bulkOverwriteGuildCommands(
 					process.env.APPLICATION_ID,
 					process.env.DEV_GUILD,
@@ -26,6 +28,6 @@ export const cmdRollout = async () => {
 			: await api.applicationCommands.bulkOverwriteGlobalCommands(process.env.APPLICATION_ID, commandData);
 
 	console.log(
-		`${chalk.bold.green('Core')} Successfully registered ${chalk.bold(result.length)} commands (${Temporal.Now.instant().toLocaleString('en-GB', { timeZone: 'Etc/UTC', timeZoneName: 'short' })})`,
+		`${chalk.bold.green("Core")} Successfully registered ${chalk.bold(result.length)} commands (${Temporal.Now.instant().toLocaleString("en-GB", { timeZone: "Etc/UTC", timeZoneName: "short" })})`,
 	);
 };

--- a/src/util/registerEvents.js
+++ b/src/util/registerEvents.js
@@ -5,10 +5,11 @@ import chalk from "chalk";
  * @param {import('../events/index.js').Event[]} events
  * @param {import('discord.js').Client} client
  */
-export function registerEvents(commands, events, client) {
+export function registerEvents(commands, actions, events, client) {
 	// Move the command map to the client context.
 	// Necessary change to move interactionCreate into its' own file.
-	client.commands = commands;
+	client.commandsMap = commands;
+	client.actionsMap = actions;
 
 	for (const event of [...events]) {
 		client[event.once ? "once" : "on"](event.name, async (...args) => {

--- a/src/util/registerEvents.js
+++ b/src/util/registerEvents.js
@@ -1,4 +1,3 @@
-import { Events } from "discord.js";
 import chalk from "chalk";
 
 /**
@@ -7,30 +6,11 @@ import chalk from "chalk";
  * @param {import('discord.js').Client} client
  */
 export function registerEvents(commands, events, client) {
-	// Create an event to handle command interactions
-	/** @type {import('../events/index.js').Event<Events.InteractionCreate>} */
-	const interactionCreateEvent = {
-		name: Events.InteractionCreate,
-		async execute(interaction) {
-			if (interaction.isCommand()) {
-				const command = commands.get(interaction.commandName);
+	// Move the command map to the client context.
+	// Necessary change to move interactionCreate into its' own file.
+	client.commands = commands;
 
-				if (!command) {
-					throw new Error(`Command '${interaction.commandName}' not found.`);
-				}
-
-				await command.execute(interaction).catch((e) => {
-					console.log(
-						`${chalk.bold.red("Command")} exception (${interaction.commandName}): \n`,
-						e,
-						` ${Temporal.Now.instant().toLocaleString("en-GB", { timeZone: "Etc/UTC", timeZoneName: "short" })}`,
-					);
-				});
-			}
-		},
-	};
-
-	for (const event of [...events, interactionCreateEvent]) {
+	for (const event of [...events]) {
 		client[event.once ? "once" : "on"](event.name, async (...args) => {
 			try {
 				return event.execute(...args);


### PR DESCRIPTION
# Description
Currently, the `interactionCreate` event is colocated within the event register; this is because of the command map, which is passed into the register.

This PR moves `interactionCreate` to its' own module (similar to the other events). The command map is passed into the `client` context, which is then accessed by `interactionCreate` during command runs.

## Why is this useful?
The colocation of `interactionCreate` in the register may be confusing to contributors, and/or it may be treated "specially". This shouldn't be the case.