### PR TITLE
[v2/bug] Handle long responses utilising the Imagine module

### DIFF
--- a/src/util/models/interactions.js
+++ b/src/util/models/interactions.js
@@ -391,9 +391,9 @@ export class InteractionMessageEvent {
 
 		return responseMsg
 			.edit({
-				content: final?.trim?.length >= 2000 ? "" : final,
+				content: final?.trim()?.length >= 2000 ? "" : final,
 				files: [
-					final.trim().length >= 2000
+					final?.trim()?.length >= 2000
 						? {
 								attachment: Buffer.from(final, "utf-8"),
 								name: "response.md",

--- a/src/util/models/interactions.js
+++ b/src/util/models/interactions.js
@@ -391,13 +391,19 @@ export class InteractionMessageEvent {
 
 		return responseMsg
 			.edit({
-				content: final,
+				content: final?.trim?.length >= 2000 ? "" : final,
 				files: [
+					final.trim().length >= 2000
+						? {
+								attachment: Buffer.from(final, "utf-8"),
+								name: "response.md",
+							}
+						: null,
 					{
 						attachment: imageGen,
 						name: "generated0.jpg",
 					},
-				],
+				].filter((e) => e !== null),
 			})
 			.catch(() => null);
 	}


### PR DESCRIPTION
target: v2.0.1

# Description
This PR adds a simple switch. When the response is over 2,000 characters and the Imagine module is being called, the final response should automatically place the final response into a file as well.