### PR TITLE
[feat] Upload logs to webserver for mobile users

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,7 @@ CLOUDFLARE_ACCOUNT_TOKEN=v1.0-abcdef1234567890abcdef1234567890abcdef1234567890ab
 # The following variables specify instruction sets and configuration for the various models in SpongeChat.
 ## The value of the variable should correspond to the key of its' responding configuration in modelConstants.js.
 MODEL_LLM_PRESET=default
+
+# !! Pastebin
+
+WASTEBIN_HOST=https://localhost:8088

--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,8 @@ CLOUDFLARE_ACCOUNT_TOKEN=v1.0-abcdef1234567890abcdef1234567890abcdef1234567890ab
 ## The value of the variable should correspond to the key of its' responding configuration in modelConstants.js.
 MODEL_LLM_PRESET=default
 
-# !! Pastebin
+# !! Wastebin 
+# Used to display logs of memories for users
+## In a docker-compose setup, you'll need to set up some sort of proxy (caddy, cloudflare tunnel) to make the "wastebin" container publicly accessible, and put the publicly accessible URL here.
 
-WASTEBIN_HOST=https://localhost:8088
+WASTEBIN_HOST=http://127.0.0.1:8088

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,15 @@ services:
       - DFLY_snapshot_cron=*/30 * * * *
     volumes:
       - dragonflydata:/data
+  wastebin:
+    image: 'quxfoo/wastebin:latest'
+    environment:
+      - WASTEBIN_DATABASE_PATH=/data/state.db
+    volumes:
+      - wastebindata:/data
+    ports:
+      - "8088:8088"
 
 volumes:
   dragonflydata:
+  wastebindata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - wastebindata:/data
     ports:
       - "8088:8088"
+    user: "0:0"
 
 volumes:
   dragonflydata:

--- a/src/commands/forget.js
+++ b/src/commands/forget.js
@@ -43,7 +43,7 @@ export default {
 		if (length === 0) return await interaction.editReply({ content: toSay });
 
 		try {
-			const request = fetch(
+			const request = await fetch(
 				`${process.env.WASTEBIN_HOST}/`,
 				{
 					method: "POST",
@@ -51,8 +51,8 @@ export default {
 						"Content-Type": "application/json",
 					},
 					body: JSON.stringify({
-						"text": log,
-						"extension": "md",
+						text: log.toString("utf-8"),
+						extension: "md",
 					}),
 				},
 			)

--- a/src/commands/forget.js
+++ b/src/commands/forget.js
@@ -56,17 +56,20 @@ export default {
 						extension: "md",
 					}),
 				},
-			)
+			).catch((e) => {
+				console.error("Error uploading logs to wastebin: " + e);
+				return false;
+			});
 
 			const button = new ButtonBuilder()
-				.setLabel('View memories')
-				.setURL(`${process.env.WASTEBIN_HOST}${(await request.json()).path}`)
+				.setLabel('View cleared memories')
+				.setURL(request !== false ? `${process.env.WASTEBIN_HOST}${(await request.json()).path}` : 'https://blahaj.ca/')
 				.setStyle(ButtonStyle.Link);
 
 			await interaction?.editReply({
 				content: `${toSay}`,
 				failIfNotExists: true,
-				components: [new ActionRowBuilder().addComponents(button)],
+				components: request !== false ? [new ActionRowBuilder().addComponents(button)] : [],
 			});
 
 			return;

--- a/src/commands/forget.js
+++ b/src/commands/forget.js
@@ -1,5 +1,6 @@
 import { ModelInteractions } from "../util/models/index.js";
 import { fetch } from "undici";
+import { ButtonBuilder, ButtonStyle, ActionRowBuilder } from "discord.js";
 
 /** @type {import('./index.js').Command} */
 export default {
@@ -56,9 +57,16 @@ export default {
 					}),
 				},
 			)
+
+			const button = new ButtonBuilder()
+				.setLabel('Chat Logs')
+				.setURL(`${process.env.WASTEBIN_HOST}${(await request.json()).path}`)
+				.setStyle(ButtonStyle.Link);
+
 			await interaction?.editReply({
-				content: `${toSay}\n\n${process.env.WASTEBIN_HOST}${(await request.json()).path}`,
+				content: `${toSay}`,
 				failIfNotExists: true,
+				components: [new ActionRowBuilder().addComponents(button)],
 			});
 
 			return;

--- a/src/commands/forget.js
+++ b/src/commands/forget.js
@@ -59,7 +59,7 @@ export default {
 			)
 
 			const button = new ButtonBuilder()
-				.setLabel('Chat Logs')
+				.setLabel('View memories')
 				.setURL(`${process.env.WASTEBIN_HOST}${(await request.json()).path}`)
 				.setStyle(ButtonStyle.Link);
 

--- a/src/commands/forget.js
+++ b/src/commands/forget.js
@@ -1,4 +1,5 @@
 import { ModelInteractions } from "../util/models/index.js";
+import { fetch } from "undici";
 
 /** @type {import('./index.js').Command} */
 export default {
@@ -42,14 +43,21 @@ export default {
 		if (length === 0) return await interaction.editReply({ content: toSay });
 
 		try {
-			await interaction?.editReply({
-				content: toSay,
-				files: [
-					{
-						attachment: log,
-						name: "context.md",
+			const request = fetch(
+				`${process.env.WASTEBIN_HOST}/`,
+				{
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
 					},
-				],
+					body: JSON.stringify({
+						"text": log,
+						"extension": "md",
+					}),
+				},
+			)
+			await interaction?.editReply({
+				content: `${toSay}\n\n${process.env.WASTEBIN_HOST}${(await request.json()).path}`,
 				failIfNotExists: true,
 			});
 


### PR DESCRIPTION
This PR introduces wastebin, for uploading logs to a webserver so that mobile users can access it, instead of a text file requiring an external viewer on discord mobile.
