### PR TITLE
[refactor] Recursion & index.js check bypass in structure loader

### DIFF
--- a/src/util/loaders.js
+++ b/src/util/loaders.js
@@ -39,7 +39,7 @@ export async function loadStructures(dir, predicate, recursive = true, allowInde
 	// Loop through all the files in the directory
 	for (const file of files) {
 		// If the file is index.js or the file does not end with .js, skip the file
-		if (file === 'index.js' || !file.endsWith('.js')) {
+		if (file === "index.js" || !file.endsWith(".js")) {
 			continue;
 		}
 

--- a/src/util/loaders.js
+++ b/src/util/loaders.js
@@ -2,10 +2,6 @@ import { readdir, stat } from "node:fs/promises";
 import { URL } from "node:url";
 import { predicate as commandPredicate } from "../commands/index.js";
 import { predicate as eventPredicate } from "../events/index.js";
-import { readdir, stat } from 'node:fs/promises';
-import { URL } from 'node:url';
-import { predicate as commandPredicate } from '../commands/index.js';
-import { predicate as eventPredicate } from '../events/index.js';
 import { basename } from "node:path";
 
 /**


### PR DESCRIPTION
## Description
This PR adds **proper** support for recursion in the structure loader. Additionally, the addition of an `allowIndex` parameter now allows certain structures that use `index.js` to opt-in to including these files during the structure loading process.

The additions in this PR will be used in the Callsystems RFC.